### PR TITLE
Fix completions capability naming to match MCP SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc",
     "postbuild": "chmod +x dist/bin/reloaderoo.js",
     "dev": "tsc --watch",

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -76,7 +76,7 @@ export class MCPProxy {
           tools: { listChanged: true },
           prompts: { listChanged: true },
           resources: { subscribe: true, listChanged: true },
-          completion: { argument: true },
+          completions: {},
           sampling: {}
         }
       }
@@ -162,7 +162,7 @@ export class MCPProxy {
           tools: {},
           prompts: {},
           resources: {},
-          completion: {},
+          completions: {},
           sampling: {}
         }
       }


### PR DESCRIPTION
## Summary

- Renames the `completion` capability key to `completions` (plural) in both the proxy server and child client capability declarations in `src/mcp-proxy.ts`
- This aligns with the `@modelcontextprotocol/sdk` >=1.25.x which validates against `completions` when registering the `CompleteRequestSchema` handler

## Problem

reloaderoo fails to start with:
```
Error: Server does not support completions (required for completion/complete)
```

The SDK's `assertRequestHandlerCapability` checks `this._capabilities.completions` but the proxy declared `completion` (singular), so the check always fails.

## Test plan

- [x] All existing tests pass (121 unit + 19 integration + 11 e2e)
- [x] Verified end-to-end with a Rust MCP server (rmcp) in Cursor — proxy starts, `restart_server` tool works, child server restarts successfully

Fixes #9
Fixes #8